### PR TITLE
Update locals.tf - fixing null error when AzFW tags not defined

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -34,7 +34,7 @@ locals {
       location            = local.virtual_networks_modules[vnet_name].vnet_location
       name                = try(vnet.firewall.default_ip_configuration.public_ip_config.name, "pip-afw-${vnet_name}")
       resource_group_name = vnet.resource_group_name
-      tags                = vnet.firewall.default_ip_configuration.tags
+      tags                = try(vnet.firewall.default_ip_configuration.tags, null)
       ip_version          = try(vnet.firewall.default_ip_configuration.public_ip_config.ip_version, "IPv4")
       sku_tier            = try(vnet.firewall.default_ip_configuration.public_ip_config.sku_tier, "Regional")
       zones               = try(vnet.firewall.default_ip_configuration.public_ip_config.zones, null)
@@ -45,7 +45,7 @@ locals {
       location            = local.virtual_networks_modules[k].vnet_location
       name                = try(v.firewall.management_ip_configuration.public_ip_config.name, "pip-afw-mgmt-${k}")
       resource_group_name = v.resource_group_name
-      tags                = v.firewall.management_ip_configuration.tags
+      tags                = try(v.firewall.management_ip_configuration.tags, null)
       ip_version          = try(v.firewall.management_ip_configuration.public_ip_config.ip_version, "IPv4")
       sku_tier            = try(v.firewall.management_ip_configuration.public_ip_config.sku_tier, "Regional")
       zones               = try(v.firewall.management_ip_configuration.public_ip_config.zones, null)


### PR DESCRIPTION
## Describe your changes

Getting a null error assignment in locals.tf on following tags assignment when no tags provided for Azure FW. 

Fixing using basic try(value, null) sequence.
fw_default_ip_configuration_pip assgnment
tags                = vnet.firewall.default_ip_configuration.tags

fw_management_ip_configuration_pip assignment
tags = v.firewall.management_ip_configuration.tags

## Issue number

NA

## Checklist before requesting a review
- [x ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [x] I have executed pre-commit on my machine
- [x] I have passed pr-check on my machine

Thanks for your cooperation!

